### PR TITLE
adding gh actions to deploy packages

### DIFF
--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -1,0 +1,23 @@
+name: Publish package
+on:
+  push:
+    branches: main
+    paths:
+      - "packages/components/package.json"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+      - name: install
+        run: npm install
+      - name: build
+        run: npm run build
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: "public"
+          check-version: false

--- a/.github/workflows/theme.yaml
+++ b/.github/workflows/theme.yaml
@@ -1,0 +1,23 @@
+name: Publish package
+on:
+  push:
+    branches: main
+    paths:
+      - "packages/theme/package.json"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+      - name: install
+        run: npm install
+      - name: build
+        run: npm run build
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: "public"
+          check-version: false

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cabin-design-system",
+  "name": "@cabindao/topo",
   "version": "0.0.1",
   "description": "Components for the CabinDAO design system",
   "main": "index.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "topo-theme",
+  "name": "@cabindao/topo-theme",
   "version": "0.0.1",
   "description": "Topo theme for the CabinDAO design system",
   "main": "lib/index.js",


### PR DESCRIPTION
Noticed that the packages weren't available on NPM. I added two github actions that will automatically publish new versions anytime it detects changes in the package.json merging into master (which is where the version bump would be).

Two things need to happen before this PR merges:
- Need to set up a `@cabindao` namespace on `npm` to house the packages
- Need to add the npm token from that namespace to the repo as a github secret called `NPM_TOKEN`